### PR TITLE
Add compute shader example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EXAMPLES
     0_HelloTriangle
     1_VertexBuffer
     2_TextureMapping
+    3_Compute
 )
 
 # Option to build all examples (default: ON)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ A simple Vulkan application setup for demonstrating RenderDoc usage with multipl
 
    # Or build only the Texture Mapping example
    cmake .. -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=2_TextureMapping
+
+   # Or build only the Compute example
+   cmake .. -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=3_Compute
    ```
 
 4. Build the project:
@@ -56,13 +59,16 @@ After building, you can run any of the examples:
 
 # Run the Texture Mapping example
 ./bin/2_TextureMapping
+
+# Run the Compute example
+./bin/3_Compute
 ```
 
 ## Using with RenderDoc
 
 1. Launch RenderDoc
 2. File -> Launch Application
-3. Select the example executable (e.g., `0_HelloTriangle`, `1_VertexBuffer`, or `2_TextureMapping`)
+3. Select the example executable (e.g., `0_HelloTriangle`, `1_VertexBuffer`, `2_TextureMapping`, or `3_Compute`)
 4. Click Launch
 5. Capture a frame by pressing F12 or using the RenderDoc UI
 6. Analyze the captured frame in RenderDoc
@@ -82,7 +88,10 @@ After building, you can run any of the examples:
   - `2_TextureMapping/` - Textured quad rendering using vertex and index buffers
     - `main.cpp` - Entry point
     - `shaders/` - GLSL shader files
-- `CMakeLists.txt` - CMake build configuration
+  - `3_Compute/` - Minimal compute shader example
+    - `main.cpp` - Entry point
+    - `shaders/` - GLSL compute shader
+  - `CMakeLists.txt` - CMake build configuration
 
 ## Examples
 
@@ -112,6 +121,13 @@ This example builds on the previous examples and demonstrates:
 - Sampling textures in fragment shaders
 - Index buffer usage for efficient rendering
 - Procedural texture generation
+
+### 3_Compute
+
+This example demonstrates a minimal compute pipeline:
+- Creates a storage buffer filled with numbers
+- Dispatches a compute shader that doubles each value
+- Reads back and prints the results to the console
 
 ## Debugging with RenderDoc
 

--- a/examples/3_Compute/main.cpp
+++ b/examples/3_Compute/main.cpp
@@ -1,0 +1,292 @@
+#include <vulkan/vulkan.h>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+#include <fstream>
+#include <cstdlib>
+
+std::vector<char> readFile(const std::string &filename) {
+    std::ifstream file(filename, std::ios::ate | std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + filename);
+    }
+    size_t fileSize = (size_t)file.tellg();
+    std::vector<char> buffer(fileSize);
+    file.seekg(0);
+    file.read(buffer.data(), fileSize);
+    file.close();
+    return buffer;
+}
+
+// Compile GLSL to SPIR-V using glslc. Fallback to precompiled SPIR-V if compilation fails.
+std::vector<char> getShaderCode(const std::string &filename) {
+    std::vector<char> code;
+    std::string command = "glslc -fshader-stage=compute " + filename + " -o tmp.spv";
+    int result = std::system(command.c_str());
+    if (result == 0) {
+        code = readFile("tmp.spv");
+        std::remove("tmp.spv");
+    } else {
+        // try precompiled
+        code = readFile(filename + ".spv");
+    }
+    return code;
+}
+
+int main() {
+    const uint32_t NUM_ELEMENTS = 16;
+    std::vector<float> data(NUM_ELEMENTS);
+    for (uint32_t i = 0; i < NUM_ELEMENTS; ++i) {
+        data[i] = static_cast<float>(i);
+    }
+
+    // Instance
+    VkInstance instance;
+    VkApplicationInfo appInfo{};
+    appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    appInfo.pApplicationName = "ComputeExample";
+    appInfo.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    createInfo.pApplicationInfo = &appInfo;
+    if (vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create instance");
+    }
+
+    // Physical device
+    uint32_t deviceCount = 0;
+    vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+    if (deviceCount == 0) {
+        throw std::runtime_error("failed to find GPUs with Vulkan support");
+    }
+    std::vector<VkPhysicalDevice> devices(deviceCount);
+    vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
+    VkPhysicalDevice physicalDevice = devices[0];
+
+    // Find compute queue family
+    uint32_t queueFamilyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilies.data());
+    uint32_t computeFamily = UINT32_MAX;
+    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
+        if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+            computeFamily = i;
+            break;
+        }
+    }
+    if (computeFamily == UINT32_MAX) {
+        throw std::runtime_error("failed to find compute queue family");
+    }
+
+    float queuePriority = 1.0f;
+    VkDeviceQueueCreateInfo queueCreateInfo{};
+    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queueCreateInfo.queueFamilyIndex = computeFamily;
+    queueCreateInfo.queueCount = 1;
+    queueCreateInfo.pQueuePriorities = &queuePriority;
+
+    VkDeviceCreateInfo deviceCreateInfo{};
+    deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    deviceCreateInfo.queueCreateInfoCount = 1;
+    deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
+
+    VkDevice device;
+    if (vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &device) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create device");
+    }
+
+    VkQueue computeQueue;
+    vkGetDeviceQueue(device, computeFamily, 0, &computeQueue);
+
+    // Create buffer
+    VkBuffer buffer;
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = sizeof(float) * NUM_ELEMENTS;
+    bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    vkCreateBuffer(device, &bufferInfo, nullptr, &buffer);
+
+    VkMemoryRequirements memReq;
+    vkGetBufferMemoryRequirements(device, buffer, &memReq);
+
+    VkPhysicalDeviceMemoryProperties memProps;
+    vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+    uint32_t memType = UINT32_MAX;
+    for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i) {
+        if ((memReq.memoryTypeBits & (1 << i)) && (memProps.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+            memType = i;
+            break;
+        }
+    }
+    if (memType == UINT32_MAX) {
+        throw std::runtime_error("failed to find suitable memory type");
+    }
+
+    VkMemoryAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memReq.size;
+    allocInfo.memoryTypeIndex = memType;
+
+    VkDeviceMemory bufferMemory;
+    vkAllocateMemory(device, &allocInfo, nullptr, &bufferMemory);
+    vkBindBufferMemory(device, buffer, bufferMemory, 0);
+
+    // Upload data
+    void* mapped;
+    vkMapMemory(device, bufferMemory, 0, bufferInfo.size, 0, &mapped);
+    memcpy(mapped, data.data(), static_cast<size_t>(bufferInfo.size));
+    vkUnmapMemory(device, bufferMemory);
+
+    // Descriptor set layout
+    VkDescriptorSetLayoutBinding layoutBinding{};
+    layoutBinding.binding = 0;
+    layoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    layoutBinding.descriptorCount = 1;
+    layoutBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+    VkDescriptorSetLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutInfo.bindingCount = 1;
+    layoutInfo.pBindings = &layoutBinding;
+
+    VkDescriptorSetLayout descriptorSetLayout;
+    vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &descriptorSetLayout);
+
+    // Pipeline layout
+    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipelineLayoutInfo.setLayoutCount = 1;
+    pipelineLayoutInfo.pSetLayouts = &descriptorSetLayout;
+
+    VkPipelineLayout pipelineLayout;
+    vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &pipelineLayout);
+
+    // Shader module
+    auto code = getShaderCode("shaders/comp.comp");
+    VkShaderModuleCreateInfo moduleInfo{};
+    moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    moduleInfo.codeSize = code.size();
+    moduleInfo.pCode = reinterpret_cast<const uint32_t*>(code.data());
+
+    VkShaderModule shaderModule;
+    vkCreateShaderModule(device, &moduleInfo, nullptr, &shaderModule);
+
+    // Compute pipeline
+    VkPipelineShaderStageCreateInfo stageInfo{};
+    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    stageInfo.module = shaderModule;
+    stageInfo.pName = "main";
+
+    VkComputePipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipelineInfo.stage = stageInfo;
+    pipelineInfo.layout = pipelineLayout;
+
+    VkPipeline pipeline;
+    vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+
+    // Descriptor pool
+    VkDescriptorPoolSize poolSize{};
+    poolSize.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    poolSize.descriptorCount = 1;
+
+    VkDescriptorPoolCreateInfo poolInfo{};
+    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolInfo.poolSizeCount = 1;
+    poolInfo.pPoolSizes = &poolSize;
+    poolInfo.maxSets = 1;
+
+    VkDescriptorPool descriptorPool;
+    vkCreateDescriptorPool(device, &poolInfo, nullptr, &descriptorPool);
+
+    // Descriptor set
+    VkDescriptorSetAllocateInfo allocInfoDS{};
+    allocInfoDS.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocInfoDS.descriptorPool = descriptorPool;
+    allocInfoDS.descriptorSetCount = 1;
+    allocInfoDS.pSetLayouts = &descriptorSetLayout;
+
+    VkDescriptorSet descriptorSet;
+    vkAllocateDescriptorSets(device, &allocInfoDS, &descriptorSet);
+
+    VkDescriptorBufferInfo bufferInfoDesc{};
+    bufferInfoDesc.buffer = buffer;
+    bufferInfoDesc.offset = 0;
+    bufferInfoDesc.range = bufferInfo.size;
+
+    VkWriteDescriptorSet descriptorWrite{};
+    descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    descriptorWrite.dstSet = descriptorSet;
+    descriptorWrite.dstBinding = 0;
+    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    descriptorWrite.descriptorCount = 1;
+    descriptorWrite.pBufferInfo = &bufferInfoDesc;
+
+    vkUpdateDescriptorSets(device, 1, &descriptorWrite, 0, nullptr);
+
+    // Command pool
+    VkCommandPool commandPool;
+    VkCommandPoolCreateInfo poolCreate{};
+    poolCreate.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolCreate.queueFamilyIndex = computeFamily;
+    poolCreate.flags = 0;
+    vkCreateCommandPool(device, &poolCreate, nullptr, &commandPool);
+
+    // Command buffer
+    VkCommandBufferAllocateInfo cbAlloc{};
+    cbAlloc.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cbAlloc.commandPool = commandPool;
+    cbAlloc.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cbAlloc.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer;
+    vkAllocateCommandBuffers(device, &cbAlloc, &commandBuffer);
+
+    VkCommandBufferBeginInfo beginInfoCB{};
+    beginInfoCB.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfoCB.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(commandBuffer, &beginInfoCB);
+
+    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+    vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipelineLayout, 0, 1, &descriptorSet, 0, nullptr);
+    vkCmdDispatch(commandBuffer, NUM_ELEMENTS, 1, 1);
+
+    vkEndCommandBuffer(commandBuffer);
+
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
+
+    vkQueueSubmit(computeQueue, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(computeQueue);
+
+    // Read back
+    vkMapMemory(device, bufferMemory, 0, bufferInfo.size, 0, &mapped);
+    memcpy(data.data(), mapped, static_cast<size_t>(bufferInfo.size));
+    vkUnmapMemory(device, bufferMemory);
+
+    for (float f : data) {
+        std::cout << f << " ";
+    }
+    std::cout << std::endl;
+
+    // Cleanup
+    vkDestroyDescriptorPool(device, descriptorPool, nullptr);
+    vkDestroyPipeline(device, pipeline, nullptr);
+    vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+    vkDestroyBuffer(device, buffer, nullptr);
+    vkFreeMemory(device, bufferMemory, nullptr);
+    vkDestroyCommandPool(device, commandPool, nullptr);
+    vkDestroyDevice(device, nullptr);
+    vkDestroyInstance(instance, nullptr);
+
+    return EXIT_SUCCESS;
+}
+

--- a/examples/3_Compute/shaders/comp.comp
+++ b/examples/3_Compute/shaders/comp.comp
@@ -1,0 +1,12 @@
+#version 450
+
+layout(local_size_x = 1) in;
+
+layout(binding = 0) buffer Data {
+    float values[];
+} dataBuf;
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    dataBuf.values[idx] = dataBuf.values[idx] * 2.0;
+}


### PR DESCRIPTION
## Summary
- add new `3_Compute` example with a minimal compute pipeline
- update CMakeLists to include the compute example
- document how to build and run it in README

## Testing
- `cmake -S . -B build -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=3_Compute` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684dad893174832bb5a2e55a4c72d728