### PR TITLE
Add compute base class and refactor examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,13 @@ FetchContent_MakeAvailable(stb)
 # Set common source files
 set(COMMON_SOURCES
     common/vulkan_app.cpp
+    common/vulkan_compute_app.cpp
 )
 
 # Set common header files
 set(COMMON_HEADERS
     common/vulkan_app.h
+    common/vulkan_compute_app.h
 )
 
 # Create common library

--- a/common/vulkan_app.cpp
+++ b/common/vulkan_app.cpp
@@ -1035,6 +1035,11 @@ VulkanApp::QueueFamilyIndices VulkanApp::findQueueFamilies(VkPhysicalDevice dev)
             indices.graphicsFamily = i;
         }
 
+        if (queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT)
+        {
+            indices.computeFamily = i;
+        }
+
         VkBool32 presentSupport = false;
         vkGetPhysicalDeviceSurfaceSupportKHR(dev, i, surface, &presentSupport);
 
@@ -1043,7 +1048,7 @@ VulkanApp::QueueFamilyIndices VulkanApp::findQueueFamilies(VkPhysicalDevice dev)
             indices.presentFamily = i;
         }
 
-        if (indices.isComplete())
+        if (indices.graphicsFamily && indices.presentFamily && indices.computeFamily)
         {
             break;
         }

--- a/common/vulkan_app.h
+++ b/common/vulkan_app.h
@@ -10,6 +10,11 @@
 #include <array>
 #include <filesystem>
 
+// Global validation and extension lists shared with helpers
+extern const std::vector<const char *> validationLayers;
+extern const std::vector<const char *> deviceExtensions;
+extern const bool enableValidationLayers;
+
 #define VULKANAPP_GETSHADERDIR \
   ((std::filesystem::path{__FILE__}.parent_path() / "shaders").generic_string() + '/')
 
@@ -112,6 +117,7 @@ protected:
   {
     std::optional<uint32_t> graphicsFamily;
     std::optional<uint32_t> presentFamily;
+    std::optional<uint32_t> computeFamily;
 
     bool isComplete()
     {

--- a/common/vulkan_compute_app.cpp
+++ b/common/vulkan_compute_app.cpp
@@ -1,0 +1,185 @@
+#include "vulkan_compute_app.h"
+#include <stdexcept>
+#include <set>
+#include <fstream>
+#include <cstdlib>
+
+VulkanComputeApp::~VulkanComputeApp() {
+    if (computeCommandPool != VK_NULL_HANDLE) {
+        vkDestroyCommandPool(device, computeCommandPool, nullptr);
+    }
+    VulkanApp::cleanup();
+}
+
+void VulkanComputeApp::initVulkan() {
+    createInstance();
+    setupDebugMessenger();
+    createSurface();
+    pickPhysicalDevice();
+    createLogicalDevice();
+    createSwapChain();
+    createImageViews();
+    createRenderPass();
+    createGraphicsPipeline();
+    createFramebuffers();
+    createCommandPool();
+    createComputeCommandPool();
+    createCommandBuffers();
+    createSyncObjects();
+}
+
+void VulkanComputeApp::createLogicalDevice() {
+    QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
+
+    std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+    std::set<uint32_t> uniqueQueueFamilies = {indices.graphicsFamily.value(), indices.presentFamily.value()};
+    if (indices.computeFamily)
+        uniqueQueueFamilies.insert(indices.computeFamily.value());
+
+    float queuePriority = 1.0f;
+    for (uint32_t qFamily : uniqueQueueFamilies) {
+        VkDeviceQueueCreateInfo qInfo{};
+        qInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        qInfo.queueFamilyIndex = qFamily;
+        qInfo.queueCount = 1;
+        qInfo.pQueuePriorities = &queuePriority;
+        queueCreateInfos.push_back(qInfo);
+    }
+
+    VkPhysicalDeviceFeatures deviceFeatures{};
+    deviceFeatures.samplerAnisotropy = VK_TRUE;
+
+    VkDeviceCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
+    createInfo.pQueueCreateInfos = queueCreateInfos.data();
+    createInfo.pEnabledFeatures = &deviceFeatures;
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
+    createInfo.ppEnabledExtensionNames = deviceExtensions.data();
+
+    if (enableValidationLayers) {
+        createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
+        createInfo.ppEnabledLayerNames = validationLayers.data();
+    } else {
+        createInfo.enabledLayerCount = 0;
+    }
+
+    if (vkCreateDevice(physicalDevice, &createInfo, nullptr, &device) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create logical device!");
+    }
+
+    vkGetDeviceQueue(device, indices.graphicsFamily.value(), 0, &graphicsQueue);
+    vkGetDeviceQueue(device, indices.presentFamily.value(), 0, &presentQueue);
+    if (indices.computeFamily)
+        vkGetDeviceQueue(device, indices.computeFamily.value(), 0, &computeQueue);
+    else
+        computeQueue = graphicsQueue;
+}
+
+void VulkanComputeApp::createComputeCommandPool() {
+    QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
+    uint32_t family = indices.computeFamily ? indices.computeFamily.value() : indices.graphicsFamily.value();
+
+    VkCommandPoolCreateInfo poolInfo{};
+    poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolInfo.queueFamilyIndex = family;
+    poolInfo.flags = 0;
+
+    if (vkCreateCommandPool(device, &poolInfo, nullptr, &computeCommandPool) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create compute command pool!");
+    }
+}
+
+VkCommandBuffer VulkanComputeApp::beginSingleTimeCommands() {
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandPool = computeCommandPool;
+    allocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer;
+    vkAllocateCommandBuffers(device, &allocInfo, &commandBuffer);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    vkBeginCommandBuffer(commandBuffer, &beginInfo);
+
+    return commandBuffer;
+}
+
+void VulkanComputeApp::endSingleTimeCommands(VkCommandBuffer commandBuffer) {
+    vkEndCommandBuffer(commandBuffer);
+
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
+
+    vkQueueSubmit(computeQueue, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(computeQueue);
+
+    vkFreeCommandBuffers(device, computeCommandPool, 1, &commandBuffer);
+}
+
+void VulkanComputeApp::createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
+                                    VkBuffer& buffer, VkDeviceMemory& bufferMemory) {
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = size;
+    bufferInfo.usage = usage;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    if (vkCreateBuffer(device, &bufferInfo, nullptr, &buffer) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create buffer!");
+    }
+
+    VkMemoryRequirements memRequirements;
+    vkGetBufferMemoryRequirements(device, buffer, &memRequirements);
+
+    VkMemoryAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memRequirements.size;
+    allocInfo.memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties);
+
+    if (vkAllocateMemory(device, &allocInfo, nullptr, &bufferMemory) != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate buffer memory!");
+    }
+
+    vkBindBufferMemory(device, buffer, bufferMemory, 0);
+}
+
+void VulkanComputeApp::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size, VkQueue queue, VkCommandPool pool) {
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandPool = pool;
+    allocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer commandBuffer;
+    vkAllocateCommandBuffers(device, &allocInfo, &commandBuffer);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    vkBeginCommandBuffer(commandBuffer, &beginInfo);
+
+    VkBufferCopy copyRegion{};
+    copyRegion.size = size;
+    vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, 1, &copyRegion);
+
+    vkEndCommandBuffer(commandBuffer);
+
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &commandBuffer;
+
+    vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(queue);
+
+    vkFreeCommandBuffers(device, pool, 1, &commandBuffer);
+}
+

--- a/common/vulkan_compute_app.h
+++ b/common/vulkan_compute_app.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "vulkan_app.h"
+
+class VulkanComputeApp : public VulkanApp {
+public:
+    VulkanComputeApp(int width, int height, const std::string& appName, const std::string& shaderDir)
+        : VulkanApp(width, height, appName, shaderDir) {}
+    virtual ~VulkanComputeApp();
+
+protected:
+    VkQueue computeQueue = VK_NULL_HANDLE;
+    VkCommandPool computeCommandPool = VK_NULL_HANDLE;
+
+    virtual void initVulkan() override;
+    virtual void createLogicalDevice();
+    void createComputeCommandPool();
+
+    VkCommandBuffer beginSingleTimeCommands();
+    void endSingleTimeCommands(VkCommandBuffer commandBuffer);
+
+    void createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
+                      VkBuffer& buffer, VkDeviceMemory& bufferMemory);
+    void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size, VkQueue queue, VkCommandPool pool);
+};

--- a/examples/1_VertexBuffer/main.cpp
+++ b/examples/1_VertexBuffer/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 #include <array>
 #include <glm/glm.hpp>

--- a/examples/3_Compute/main.cpp
+++ b/examples/3_Compute/main.cpp
@@ -1,292 +1,136 @@
-#include <vulkan/vulkan.h>
+#include "vulkan_compute_app.h"
 #include <iostream>
-#include <stdexcept>
 #include <vector>
-#include <fstream>
-#include <cstdlib>
+#include <cstring>
 
-std::vector<char> readFile(const std::string &filename) {
-    std::ifstream file(filename, std::ios::ate | std::ios::binary);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open file: " + filename);
-    }
-    size_t fileSize = (size_t)file.tellg();
-    std::vector<char> buffer(fileSize);
-    file.seekg(0);
-    file.read(buffer.data(), fileSize);
-    file.close();
-    return buffer;
-}
+class ComputeExample : public VulkanComputeApp {
+public:
+    ComputeExample() : VulkanComputeApp(1,1,"Compute Example", VULKANAPP_GETSHADERDIR) {}
 
-// Compile GLSL to SPIR-V using glslc. Fallback to precompiled SPIR-V if compilation fails.
-std::vector<char> getShaderCode(const std::string &filename) {
-    std::vector<char> code;
-    std::string command = "glslc -fshader-stage=compute " + filename + " -o tmp.spv";
-    int result = std::system(command.c_str());
-    if (result == 0) {
-        code = readFile("tmp.spv");
-        std::remove("tmp.spv");
-    } else {
-        // try precompiled
-        code = readFile(filename + ".spv");
+    void runExample() {
+        const uint32_t NUM_ELEMENTS = 16;
+        std::vector<float> data(NUM_ELEMENTS);
+        for (uint32_t i=0;i<NUM_ELEMENTS;++i) data[i] = static_cast<float>(i);
+
+        VkBuffer buffer; VkDeviceMemory bufferMemory;
+        createBuffer(sizeof(float)*NUM_ELEMENTS,
+                     VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                     buffer, bufferMemory);
+
+        void* mapped;
+        vkMapMemory(device, bufferMemory, 0, VK_WHOLE_SIZE, 0, &mapped);
+        memcpy(mapped, data.data(), sizeof(float)*NUM_ELEMENTS);
+        vkUnmapMemory(device, bufferMemory);
+
+        VkDescriptorSetLayoutBinding layoutBinding{};
+        layoutBinding.binding = 0;
+        layoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        layoutBinding.descriptorCount = 1;
+        layoutBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+        VkDescriptorSetLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layoutInfo.bindingCount = 1;
+        layoutInfo.pBindings = &layoutBinding;
+        VkDescriptorSetLayout descriptorSetLayout;
+        vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &descriptorSetLayout);
+
+        VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+        pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        pipelineLayoutInfo.setLayoutCount = 1;
+        pipelineLayoutInfo.pSetLayouts = &descriptorSetLayout;
+        VkPipelineLayout pipelineLayout;
+        vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &pipelineLayout);
+
+        auto code = compileShader("comp.comp", VK_SHADER_STAGE_COMPUTE_BIT);
+        VkShaderModuleCreateInfo moduleInfo{};
+        moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        moduleInfo.codeSize = code.size();
+        moduleInfo.pCode = reinterpret_cast<const uint32_t*>(code.data());
+        VkShaderModule shaderModule;
+        vkCreateShaderModule(device, &moduleInfo, nullptr, &shaderModule);
+
+        VkPipelineShaderStageCreateInfo stage{};
+        stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        stage.module = shaderModule;
+        stage.pName = "main";
+
+        VkComputePipelineCreateInfo pipelineInfo{};
+        pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pipelineInfo.stage = stage;
+        pipelineInfo.layout = pipelineLayout;
+        VkPipeline pipeline;
+        vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+
+        VkDescriptorPoolSize poolSize{};
+        poolSize.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        poolSize.descriptorCount = 1;
+        VkDescriptorPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        poolInfo.poolSizeCount = 1;
+        poolInfo.pPoolSizes = &poolSize;
+        poolInfo.maxSets = 1;
+        VkDescriptorPool descriptorPool;
+        vkCreateDescriptorPool(device, &poolInfo, nullptr, &descriptorPool);
+
+        VkDescriptorSetAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocInfo.descriptorPool = descriptorPool;
+        allocInfo.descriptorSetCount = 1;
+        allocInfo.pSetLayouts = &descriptorSetLayout;
+        VkDescriptorSet descriptorSet;
+        vkAllocateDescriptorSets(device, &allocInfo, &descriptorSet);
+
+        VkDescriptorBufferInfo bufferInfo{};
+        bufferInfo.buffer = buffer;
+        bufferInfo.offset = 0;
+        bufferInfo.range = sizeof(float)*NUM_ELEMENTS;
+        VkWriteDescriptorSet write{};
+        write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write.dstSet = descriptorSet;
+        write.dstBinding = 0;
+        write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        write.descriptorCount = 1;
+        write.pBufferInfo = &bufferInfo;
+        vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
+
+        VkCommandBuffer commandBuffer = beginSingleTimeCommands();
+        vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+        vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipelineLayout, 0, 1, &descriptorSet, 0, nullptr);
+        vkCmdDispatch(commandBuffer, NUM_ELEMENTS, 1, 1);
+        endSingleTimeCommands(commandBuffer);
+
+        vkMapMemory(device, bufferMemory, 0, VK_WHOLE_SIZE, 0, &mapped);
+        memcpy(data.data(), mapped, sizeof(float)*NUM_ELEMENTS);
+        vkUnmapMemory(device, bufferMemory);
+
+        for(float f : data) std::cout << f << " ";
+        std::cout << std::endl;
+
+        vkDestroyDescriptorPool(device, descriptorPool, nullptr);
+        vkDestroyPipeline(device, pipeline, nullptr);
+        vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+        vkDestroyBuffer(device, buffer, nullptr);
+        vkFreeMemory(device, bufferMemory, nullptr);
     }
-    return code;
-}
+
+    void init() {
+        createInstance();
+        setupDebugMessenger();
+        pickPhysicalDevice();
+        createLogicalDevice();
+        createComputeCommandPool();
+    }
+};
 
 int main() {
-    const uint32_t NUM_ELEMENTS = 16;
-    std::vector<float> data(NUM_ELEMENTS);
-    for (uint32_t i = 0; i < NUM_ELEMENTS; ++i) {
-        data[i] = static_cast<float>(i);
-    }
-
-    // Instance
-    VkInstance instance;
-    VkApplicationInfo appInfo{};
-    appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    appInfo.pApplicationName = "ComputeExample";
-    appInfo.apiVersion = VK_API_VERSION_1_0;
-
-    VkInstanceCreateInfo createInfo{};
-    createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    createInfo.pApplicationInfo = &appInfo;
-    if (vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
-        throw std::runtime_error("failed to create instance");
-    }
-
-    // Physical device
-    uint32_t deviceCount = 0;
-    vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
-    if (deviceCount == 0) {
-        throw std::runtime_error("failed to find GPUs with Vulkan support");
-    }
-    std::vector<VkPhysicalDevice> devices(deviceCount);
-    vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
-    VkPhysicalDevice physicalDevice = devices[0];
-
-    // Find compute queue family
-    uint32_t queueFamilyCount = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, nullptr);
-    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilies.data());
-    uint32_t computeFamily = UINT32_MAX;
-    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
-        if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
-            computeFamily = i;
-            break;
-        }
-    }
-    if (computeFamily == UINT32_MAX) {
-        throw std::runtime_error("failed to find compute queue family");
-    }
-
-    float queuePriority = 1.0f;
-    VkDeviceQueueCreateInfo queueCreateInfo{};
-    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queueCreateInfo.queueFamilyIndex = computeFamily;
-    queueCreateInfo.queueCount = 1;
-    queueCreateInfo.pQueuePriorities = &queuePriority;
-
-    VkDeviceCreateInfo deviceCreateInfo{};
-    deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-    deviceCreateInfo.queueCreateInfoCount = 1;
-    deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
-
-    VkDevice device;
-    if (vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &device) != VK_SUCCESS) {
-        throw std::runtime_error("failed to create device");
-    }
-
-    VkQueue computeQueue;
-    vkGetDeviceQueue(device, computeFamily, 0, &computeQueue);
-
-    // Create buffer
-    VkBuffer buffer;
-    VkBufferCreateInfo bufferInfo{};
-    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufferInfo.size = sizeof(float) * NUM_ELEMENTS;
-    bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    vkCreateBuffer(device, &bufferInfo, nullptr, &buffer);
-
-    VkMemoryRequirements memReq;
-    vkGetBufferMemoryRequirements(device, buffer, &memReq);
-
-    VkPhysicalDeviceMemoryProperties memProps;
-    vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
-    uint32_t memType = UINT32_MAX;
-    for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i) {
-        if ((memReq.memoryTypeBits & (1 << i)) && (memProps.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
-            memType = i;
-            break;
-        }
-    }
-    if (memType == UINT32_MAX) {
-        throw std::runtime_error("failed to find suitable memory type");
-    }
-
-    VkMemoryAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    allocInfo.allocationSize = memReq.size;
-    allocInfo.memoryTypeIndex = memType;
-
-    VkDeviceMemory bufferMemory;
-    vkAllocateMemory(device, &allocInfo, nullptr, &bufferMemory);
-    vkBindBufferMemory(device, buffer, bufferMemory, 0);
-
-    // Upload data
-    void* mapped;
-    vkMapMemory(device, bufferMemory, 0, bufferInfo.size, 0, &mapped);
-    memcpy(mapped, data.data(), static_cast<size_t>(bufferInfo.size));
-    vkUnmapMemory(device, bufferMemory);
-
-    // Descriptor set layout
-    VkDescriptorSetLayoutBinding layoutBinding{};
-    layoutBinding.binding = 0;
-    layoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    layoutBinding.descriptorCount = 1;
-    layoutBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    VkDescriptorSetLayoutCreateInfo layoutInfo{};
-    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layoutInfo.bindingCount = 1;
-    layoutInfo.pBindings = &layoutBinding;
-
-    VkDescriptorSetLayout descriptorSetLayout;
-    vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &descriptorSetLayout);
-
-    // Pipeline layout
-    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
-    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pipelineLayoutInfo.setLayoutCount = 1;
-    pipelineLayoutInfo.pSetLayouts = &descriptorSetLayout;
-
-    VkPipelineLayout pipelineLayout;
-    vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &pipelineLayout);
-
-    // Shader module
-    auto code = getShaderCode("shaders/comp.comp");
-    VkShaderModuleCreateInfo moduleInfo{};
-    moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    moduleInfo.codeSize = code.size();
-    moduleInfo.pCode = reinterpret_cast<const uint32_t*>(code.data());
-
-    VkShaderModule shaderModule;
-    vkCreateShaderModule(device, &moduleInfo, nullptr, &shaderModule);
-
-    // Compute pipeline
-    VkPipelineShaderStageCreateInfo stageInfo{};
-    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
-    stageInfo.pName = "main";
-
-    VkComputePipelineCreateInfo pipelineInfo{};
-    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    pipelineInfo.stage = stageInfo;
-    pipelineInfo.layout = pipelineLayout;
-
-    VkPipeline pipeline;
-    vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
-
-    // Descriptor pool
-    VkDescriptorPoolSize poolSize{};
-    poolSize.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    poolSize.descriptorCount = 1;
-
-    VkDescriptorPoolCreateInfo poolInfo{};
-    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = 1;
-    poolInfo.pPoolSizes = &poolSize;
-    poolInfo.maxSets = 1;
-
-    VkDescriptorPool descriptorPool;
-    vkCreateDescriptorPool(device, &poolInfo, nullptr, &descriptorPool);
-
-    // Descriptor set
-    VkDescriptorSetAllocateInfo allocInfoDS{};
-    allocInfoDS.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfoDS.descriptorPool = descriptorPool;
-    allocInfoDS.descriptorSetCount = 1;
-    allocInfoDS.pSetLayouts = &descriptorSetLayout;
-
-    VkDescriptorSet descriptorSet;
-    vkAllocateDescriptorSets(device, &allocInfoDS, &descriptorSet);
-
-    VkDescriptorBufferInfo bufferInfoDesc{};
-    bufferInfoDesc.buffer = buffer;
-    bufferInfoDesc.offset = 0;
-    bufferInfoDesc.range = bufferInfo.size;
-
-    VkWriteDescriptorSet descriptorWrite{};
-    descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    descriptorWrite.dstSet = descriptorSet;
-    descriptorWrite.dstBinding = 0;
-    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    descriptorWrite.descriptorCount = 1;
-    descriptorWrite.pBufferInfo = &bufferInfoDesc;
-
-    vkUpdateDescriptorSets(device, 1, &descriptorWrite, 0, nullptr);
-
-    // Command pool
-    VkCommandPool commandPool;
-    VkCommandPoolCreateInfo poolCreate{};
-    poolCreate.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-    poolCreate.queueFamilyIndex = computeFamily;
-    poolCreate.flags = 0;
-    vkCreateCommandPool(device, &poolCreate, nullptr, &commandPool);
-
-    // Command buffer
-    VkCommandBufferAllocateInfo cbAlloc{};
-    cbAlloc.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-    cbAlloc.commandPool = commandPool;
-    cbAlloc.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    cbAlloc.commandBufferCount = 1;
-
-    VkCommandBuffer commandBuffer;
-    vkAllocateCommandBuffers(device, &cbAlloc, &commandBuffer);
-
-    VkCommandBufferBeginInfo beginInfoCB{};
-    beginInfoCB.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    beginInfoCB.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-    vkBeginCommandBuffer(commandBuffer, &beginInfoCB);
-
-    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
-    vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipelineLayout, 0, 1, &descriptorSet, 0, nullptr);
-    vkCmdDispatch(commandBuffer, NUM_ELEMENTS, 1, 1);
-
-    vkEndCommandBuffer(commandBuffer);
-
-    VkSubmitInfo submitInfo{};
-    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &commandBuffer;
-
-    vkQueueSubmit(computeQueue, 1, &submitInfo, VK_NULL_HANDLE);
-    vkQueueWaitIdle(computeQueue);
-
-    // Read back
-    vkMapMemory(device, bufferMemory, 0, bufferInfo.size, 0, &mapped);
-    memcpy(data.data(), mapped, static_cast<size_t>(bufferInfo.size));
-    vkUnmapMemory(device, bufferMemory);
-
-    for (float f : data) {
-        std::cout << f << " ";
-    }
-    std::cout << std::endl;
-
-    // Cleanup
-    vkDestroyDescriptorPool(device, descriptorPool, nullptr);
-    vkDestroyPipeline(device, pipeline, nullptr);
-    vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
-    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
-    vkDestroyBuffer(device, buffer, nullptr);
-    vkFreeMemory(device, bufferMemory, nullptr);
-    vkDestroyCommandPool(device, commandPool, nullptr);
-    vkDestroyDevice(device, nullptr);
-    vkDestroyInstance(instance, nullptr);
-
-    return EXIT_SUCCESS;
+    ComputeExample app;
+    app.init();
+    app.runExample();
+    return 0;
 }
 

--- a/examples/4_ComputeSkinning/main.cpp
+++ b/examples/4_ComputeSkinning/main.cpp
@@ -1,4 +1,4 @@
-#include "vulkan_app.h"
+#include "vulkan_compute_app.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
@@ -53,10 +53,10 @@ struct ComputeVertex {
 };
 
 // Texture mapping example class that extends VulkanApp
-class ComputeSkinningApp : public VulkanApp {
+class ComputeSkinningApp : public VulkanComputeApp {
 public:
     ComputeSkinningApp(int width, int height, const std::string& appName)
-        : VulkanApp(width, height, appName, VULKANAPP_GETSHADERDIR) {
+        : VulkanComputeApp(width, height, appName, VULKANAPP_GETSHADERDIR) {
         // Vertex data used for the compute skinning stage
         computeVertices = {
             {{-0.5f, -0.5f}, {0.0f, 0.0f}, {0, 1}, {1.0f, 0.0f}},  // Bottom left
@@ -550,33 +550,6 @@ protected:
         vkUpdateDescriptorSets(device, 1, &descriptorWrite, 0, nullptr);
     }
 
-    // Helper function to create buffer
-    void createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, VkBuffer& buffer, VkDeviceMemory& bufferMemory) {
-        VkBufferCreateInfo bufferInfo{};
-        bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-        bufferInfo.size = size;
-        bufferInfo.usage = usage;
-        bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-        if (vkCreateBuffer(device, &bufferInfo, nullptr, &buffer) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to create buffer!");
-        }
-
-        VkMemoryRequirements memRequirements;
-        vkGetBufferMemoryRequirements(device, buffer, &memRequirements);
-
-        VkMemoryAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        allocInfo.allocationSize = memRequirements.size;
-        allocInfo.memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties);
-
-        if (vkAllocateMemory(device, &allocInfo, nullptr, &bufferMemory) != VK_SUCCESS) {
-            throw std::runtime_error("Failed to allocate buffer memory!");
-        }
-
-        vkBindBufferMemory(device, buffer, bufferMemory, 0);
-    }
-
     // Helper function to copy buffer
     void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size) {
         VkCommandBufferAllocateInfo allocInfo{};
@@ -611,19 +584,6 @@ protected:
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }
 
-    // Helper function to find memory type
-    uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) {
-        VkPhysicalDeviceMemoryProperties memProperties;
-        vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
-
-        for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
-            if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
-                return i;
-            }
-        }
-
-        throw std::runtime_error("Failed to find suitable memory type!");
-    }
 
     // Helper function to create image
     void createImage(uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& imageMemory) {


### PR DESCRIPTION
## Summary
- add `VulkanComputeApp` with compute queue/pool helpers
- extend queue family detection for compute support
- refactor compute examples to use the new class
- update VertexBuffer example build
- include new sources in CMake

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_684db9ed49a4832b854ce626bf545afa