### PR TITLE
Fix compute example initialization

### DIFF
--- a/examples/3_Compute/main.cpp
+++ b/examples/3_Compute/main.cpp
@@ -119,8 +119,14 @@ public:
     }
 
     void init() {
+        // Initialize GLFW and create a hidden window so that the surface
+        // extension is enabled. This avoids validation errors when the
+        // base helpers query for presentation support.
+        initWindow();
+        glfwHideWindow(window);
         createInstance();
         setupDebugMessenger();
+        createSurface();
         pickPhysicalDevice();
         createLogicalDevice();
         createComputeCommandPool();


### PR DESCRIPTION
## Summary
- create a hidden window and surface in the compute example to enable `VK_KHR_surface`

## Testing
- `cmake .. -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=3_Compute` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5247814832b8843ce5826fa339a