### PR TITLE
Enhance compute skinning with 3D cylinder

### DIFF
--- a/examples/4_ComputeSkinning/shaders/comp.comp
+++ b/examples/4_ComputeSkinning/shaders/comp.comp
@@ -3,7 +3,7 @@
 layout(local_size_x = 1) in;
 
 struct VertexIn {
-    vec2 pos;
+    vec3 pos;
     vec2 texCoord;
     uvec2 boneIDs;
     vec2 weights;
@@ -14,7 +14,7 @@ layout(binding = 0) readonly buffer Src {
 } srcData;
 
 struct VertexOut {
-    vec2 pos;
+    vec3 pos;
     vec2 texCoord;
 };
 
@@ -29,10 +29,10 @@ layout(binding = 2) uniform Bones {
 void main() {
     uint idx = gl_GlobalInvocationID.x;
     VertexIn vin = srcData.vertices[idx];
-    vec4 pos = vec4(vin.pos, 0.0, 1.0);
+    vec4 pos = vec4(vin.pos, 1.0);
     vec4 t0 = bonesUBO.bones[vin.boneIDs.x] * pos;
     vec4 t1 = bonesUBO.bones[vin.boneIDs.y] * pos;
     vec4 skinned = vin.weights.x * t0 + vin.weights.y * t1;
-    dstData.vertices[idx].pos = skinned.xy;
+    dstData.vertices[idx].pos = skinned.xyz;
     dstData.vertices[idx].texCoord = vin.texCoord;
 }

--- a/examples/4_ComputeSkinning/shaders/shader.vert
+++ b/examples/4_ComputeSkinning/shaders/shader.vert
@@ -1,11 +1,11 @@
 #version 450
 
-layout(location = 0) in vec2 inPosition;
+layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec2 inTexCoord;
 
 layout(location = 0) out vec2 fragTexCoord;
 
 void main() {
-    gl_Position = vec4(inPosition, 0.0, 1.0);
+    gl_Position = vec4(inPosition, 1.0);
     fragTexCoord = inTexCoord;
 }


### PR DESCRIPTION
## Summary
- update compute skinning example to create a 3D cylinder mesh
- allow compute shader to skin 3D vertices and rotate the entire model
- adjust shaders for vec3 positions

## Testing
- `cmake -B build -S .` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df3e46784832bb0e665f8794d43b3