### PR TITLE
Add camera projection to ComputeSkinning example

### DIFF
--- a/examples/4_ComputeSkinning/shaders/shader.vert
+++ b/examples/4_ComputeSkinning/shaders/shader.vert
@@ -5,7 +5,11 @@ layout(location = 1) in vec2 inTexCoord;
 
 layout(location = 0) out vec2 fragTexCoord;
 
+layout(binding = 1) uniform CameraUBO {
+    mat4 viewProj;
+} camera;
+
 void main() {
-    gl_Position = vec4(inPosition, 1.0);
+    gl_Position = camera.viewProj * vec4(inPosition, 1.0);
     fragTexCoord = inTexCoord;
 }


### PR DESCRIPTION
## Summary
- integrate a simple camera with view/projection matrix in 4_ComputeSkinning
- pass camera data via uniform buffer
- update descriptor layouts and sets
- modify vertex shader to use the new uniform

## Testing
- `cmake .. -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=4_ComputeSkinning` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684e01ff6834832b96a8ef3bedd7f1b6