### PR TITLE
Implement adjustable FPS cap

### DIFF
--- a/common/vulkan_app.cpp
+++ b/common/vulkan_app.cpp
@@ -8,6 +8,8 @@
 #include <limits>
 #include <fstream>
 #include <filesystem>
+#include <chrono>
+#include <thread>
 
 // Constants
 const std::vector<const char *> validationLayers = {
@@ -186,8 +188,21 @@ void VulkanApp::mainLoop()
 {
     while (!glfwWindowShouldClose(window))
     {
+        auto frameStart = std::chrono::steady_clock::now();
         glfwPollEvents();
         drawFrame();
+
+        if (targetFPS > 0.0f)
+        {
+            auto frameEnd = std::chrono::steady_clock::now();
+            std::chrono::duration<float> elapsed = frameEnd - frameStart;
+            float targetSeconds = 1.0f / targetFPS;
+            if (elapsed.count() < targetSeconds)
+            {
+                std::this_thread::sleep_for(
+                    std::chrono::duration<float>(targetSeconds - elapsed.count()));
+            }
+        }
     }
 
     vkDeviceWaitIdle(device);

--- a/common/vulkan_app.h
+++ b/common/vulkan_app.h
@@ -37,6 +37,9 @@ public:
 
   void run();
 
+  void setTargetFPS(float fps) { targetFPS = fps; }
+  float getTargetFPS() const { return targetFPS; }
+
 private:
   const std::string shaderDir;
 
@@ -46,6 +49,8 @@ protected:
   int windowHeight;
   std::string appName;
   GLFWwindow *window = nullptr;
+  // Desired frame rate. Defaults to 30 FPS. When 0, rendering runs without delay.
+  float targetFPS = 30.0f;
 
   // Vulkan objects
   VkInstance instance = VK_NULL_HANDLE;

--- a/examples/4_ComputeSkinning/main.cpp
+++ b/examples/4_ComputeSkinning/main.cpp
@@ -77,6 +77,7 @@ public:
     ComputeSkinningApp(int width, int height, const std::string &appName)
         : VulkanComputeApp(width, height, appName, VULKANAPP_GETSHADERDIR)
     {
+        setTargetFPS(30.0f);
         // Generate a cylinder mesh and store skinning weights per-vertex
         const uint32_t SEGMENTS = 20; // vertical subdivisions
         const uint32_t SLICES = 20;   // around circumference


### PR DESCRIPTION
## Summary
- add `targetFPS` setting in `VulkanApp`
- throttle frame rate in the base `mainLoop`
- set `ComputeSkinningApp` to 30 FPS
- default to 30 FPS

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684e05b6ab98832b8a1a73765f0f5c65