### PR TITLE
Fix compute skinning struct layout

### DIFF
--- a/examples/4_ComputeSkinning/main.cpp
+++ b/examples/4_ComputeSkinning/main.cpp
@@ -21,9 +21,9 @@ constexpr bool USE_COMPUTE_SKINNING = false;
 #include <glm/gtc/matrix_transform.hpp>
 
 // Vertex structure with position and texture coordinates
-struct Vertex
+struct alignas(16) Vertex
 {
-    glm::vec3 pos;
+    alignas(16) glm::vec3 pos;
     glm::vec2 texCoord;
 
     static VkVertexInputBindingDescription getBindingDescription()
@@ -57,13 +57,17 @@ struct Vertex
 };
 
 // Vertex layout used during the compute pass
-struct ComputeVertex
+struct alignas(16) ComputeVertex
 {
-    glm::vec3 pos;
+    alignas(16) glm::vec3 pos;
     glm::vec2 texCoord;
     glm::uvec2 boneIDs;
     glm::vec2 weights;
 };
+
+static_assert(sizeof(Vertex) == 32, "Vertex size mismatch with shader layout");
+static_assert(sizeof(ComputeVertex) == 48,
+              "ComputeVertex size mismatch with shader layout");
 
 struct CameraUBO
 {


### PR DESCRIPTION
## Summary
- align CPU vertex structures to match shader layout
- add static asserts for structure sizes

## Testing
- `cmake .. -DBUILD_ALL_EXAMPLES=OFF -DEXAMPLE=4_ComputeSkinning` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684e0c57e5e8832bb29b3395caf68f4f