### PR TITLE
Enable shader debug info for RenderDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ After building, you can run any of the examples:
 5. Capture a frame by pressing F12 or using the RenderDoc UI
 6. Analyze the captured frame in RenderDoc
 
+The example runner compiles shaders on the fly using `glslc -g -O0`, so the
+SPIR-V binaries contain debug information. When you open a capture in RenderDoc
+you'll be able to see and step through the original GLSL source.
+
 ## Project Structure
 
 - `common/` - Common code shared between examples

--- a/common/vulkan_app.cpp
+++ b/common/vulkan_app.cpp
@@ -98,8 +98,8 @@ std::vector<char> VulkanApp::compileShader(const std::string &filename, VkShader
     sourceFile.write(shaderSource.data(), shaderSource.size());
     sourceFile.close();
 
-    // Compile the shader using glslc
-    std::string command = "glslc " + shaderTypeFlag + " " + sourceFilename + " -o " + tempFilename;
+    // Compile the shader using glslc with debug information
+    std::string command = "glslc -g -O0 " + shaderTypeFlag + " " + sourceFilename + " -o " + tempFilename;
     int result = std::system(command.c_str());
 
     if (result != 0)


### PR DESCRIPTION
## Summary
- compile shaders with `glslc -g -O0` for debug info
- document that shaders are built with debug info so RenderDoc can display the original GLSL

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684f10e4e2d0832b93f32beeba8ed855