### PR TITLE
Add RenderDoc capture build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ set(EXAMPLES
 # Option to build all examples (default: ON)
 option(BUILD_ALL_EXAMPLES "Build all examples" ON)
 
+# Optional RenderDoc capture support
+option(ENABLE_RENDERDOC_CAPTURE "Enable RenderDoc frame capture" OFF)
+set(RENDERDOC_INCLUDE_DIR "" CACHE PATH "Path to renderdoc_app.h")
+
 # Option to select which example to build (used only if BUILD_ALL_EXAMPLES is OFF)
 set(EXAMPLE "0_HelloTriangle" CACHE STRING "Example to build when BUILD_ALL_EXAMPLES is OFF")
 set_property(CACHE EXAMPLE PROPERTY STRINGS ${EXAMPLES})
@@ -116,6 +120,13 @@ function(add_example name)
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}
         ${stb_SOURCE_DIR}
     )
+
+    if(ENABLE_RENDERDOC_CAPTURE)
+        target_compile_definitions(${name} PRIVATE ENABLE_RENDERDOC_CAPTURE)
+        if(RENDERDOC_INCLUDE_DIR)
+            target_include_directories(${name} PRIVATE ${RENDERDOC_INCLUDE_DIR})
+        endif()
+    endif()
 
     # Copy shader files to build directory
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}/shaders DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/bin)

--- a/README.md
+++ b/README.md
@@ -166,3 +166,18 @@ When using RenderDoc with these examples, you can:
 6. Debug UV mapping issues
 
 This is particularly useful for understanding how Vulkan works and for debugging rendering issues.
+
+### Enabling RenderDoc Capture in the Compute Example
+
+The `3_Compute` example contains optional code that programmatically triggers a
+RenderDoc capture around the compute dispatch. To enable this feature during the
+build, configure CMake with the following options:
+
+```bash
+cmake .. -DENABLE_RENDERDOC_CAPTURE=ON -DRENDERDOC_INCLUDE_DIR=/path/to/renderdoc/include
+```
+
+`RENDERDOC_INCLUDE_DIR` should point to the directory containing
+`renderdoc_app.h` (for example `C:/Program Files/RenderDoc/include` on Windows or
+`/usr/include` on Linux). When enabled, running the compute example will produce
+a capture without requiring manual interaction in the RenderDoc UI.

--- a/examples/3_Compute/main.cpp
+++ b/examples/3_Compute/main.cpp
@@ -3,6 +3,10 @@
 #include <vector>
 #include <cstring>
 
+#ifdef ENABLE_RENDERDOC_CAPTURE
+#include <renderdoc_app.h>
+#endif
+
 class ComputeExample : public VulkanComputeApp
 {
 public:
@@ -10,6 +14,20 @@ public:
 
     void runExample()
     {
+#ifdef ENABLE_RENDERDOC_CAPTURE
+        static RENDERDOC_API_1_6_0 *rdoc_api = nullptr;
+        if (rdoc_api == nullptr)
+        {
+            if (RENDERDOC_GetAPI(RENDERDOC_API_VERSION, (void **)&rdoc_api) != 1)
+            {
+                rdoc_api = nullptr;
+            }
+        }
+        if (rdoc_api)
+        {
+            rdoc_api->StartFrameCapture(nullptr, nullptr);
+        }
+#endif
         const uint32_t NUM_ELEMENTS = 16;
         std::vector<float> data(NUM_ELEMENTS);
         std::cout << "Running compute shader example with " << NUM_ELEMENTS << " elements." << std::endl;
@@ -129,6 +147,12 @@ public:
         vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
         vkDestroyBuffer(device, buffer, nullptr);
         vkFreeMemory(device, bufferMemory, nullptr);
+#ifdef ENABLE_RENDERDOC_CAPTURE
+        if (rdoc_api)
+        {
+            rdoc_api->EndFrameCapture(nullptr, nullptr);
+        }
+#endif
     }
 
     void init()


### PR DESCRIPTION
## Summary
- add CMake option to enable RenderDoc capture and specify include directory
- document how to enable capture in `3_Compute`

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684f37ce904c832bbc3cef1287178162