### PR TITLE
Add separate buffers to compute example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ option(ENABLE_RENDERDOC_CAPTURE "Enable RenderDoc frame capture" OFF)
 set(RENDERDOC_INCLUDE_DIR "" CACHE PATH "Path to renderdoc_app.h")
 
 # DONOTCHECKIN
-set(ENABLE_RENDERDOC_CAPTURE ON)
-set(RENDERDOC_INCLUDE_DIR "C:/Program Files/RenderDocForMetaQuest/")
+set(ENABLE_RENDERDOC_CAPTURE OFF)
+set(RENDERDOC_INCLUDE_DIR "")
 
 # Option to select which example to build (used only if BUILD_ALL_EXAMPLES is OFF)
 set(EXAMPLE "0_HelloTriangle" CACHE STRING "Example to build when BUILD_ALL_EXAMPLES is OFF")

--- a/examples/3_Compute/shaders/comp.comp
+++ b/examples/3_Compute/shaders/comp.comp
@@ -2,11 +2,15 @@
 
 layout(local_size_x = 1) in;
 
-layout(binding = 0) buffer Data {
+layout(binding = 0) readonly buffer InputData {
     float values[];
-} dataBuf;
+} inputBuf;
+
+layout(binding = 1) writeonly buffer OutputData {
+    float values[];
+} outputBuf;
 
 void main() {
     uint idx = gl_GlobalInvocationID.x;
-    dataBuf.values[idx] = dataBuf.values[idx] * 2.0;
+    outputBuf.values[idx] = inputBuf.values[idx] * 2.0;
 }


### PR DESCRIPTION
## Summary
- modify compute shader to read from an input buffer and write to an output buffer
- update `3_Compute` example code for new buffers
- disable RenderDoc by default in CMake to allow builds without RenderDoc installed

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/bin/3_Compute` *(fails: `glfwSetWindowUserPointer` assertion)*

------
https://chatgpt.com/codex/tasks/task_e_684f50cf77e8832bbcbcde90d154e26c